### PR TITLE
Add XFBML.parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ The following is a basic example of such a configuration:
 ```js
   FB = {
     appId: 'YOUR APP ID',
-    version: 'v2.3',
+    version: 'v2.7',
     xfbml: true
   }
 ```
+
+You need to replace **YOUR APP ID** with your own Facebook App ID (which can be found in the Facebook developer dashboard)
+and also set the **version** to Facebook API version you would like to use.
 
 ### Skipping Facebook SDK init
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The methods implemented are:
   - login
   - logout
   - getAuthResponse
+* Misc
+  - XFBML.parse
 
 ## Installation
 
@@ -112,6 +114,27 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+### Forcing XFBML tag re-parsing
+
+The loading and initialization of the Facebook SDK is asynchronous so it may happen that you use XFBML tags and these
+are not properly parsed from the SDK: this could happen, for example, because you add such a tag as part of a component
+mark-up which is added to the DOM after the parsing init script already run. In such a case you may find it useful to rescue
+to call the [xfbml_parse](https://developers.facebook.com/docs/reference/javascript/FB.XFBML.parse) function explicitly:
+
+```js
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  fb: Ember.inject.service(),
+
+  didInsertElement() {
+    return this.get('fb').xfbml_parse();
+  }
+});
+```
+
+You may also try to schedule the same code to run `afterRender` from your route's `controller` hook.
 
 ## Example app
 

--- a/addon/services/fb.js
+++ b/addon/services/fb.js
@@ -141,5 +141,15 @@ export default Ember.Service.extend({
 
   getAuthResponse: function() {
     return window.FB.getAuthResponse();
+  },
+
+  xfbml_parse: function() {
+    return this.FBInit().then(function() {
+      return new Ember.RSVP.Promise(function(resolve) {
+        return window.FB.XFBML.parse(undefined, function() {
+          Ember.run(null, resolve, 'XFBML.parse');
+        });
+      });
+    });
   }
 });


### PR DESCRIPTION
- Minor issue on README
- Add implementation for FB.XFBML.parse function: it could be useful to force re-parsing of XFBML tags.