### PR TITLE
Allow FBInit to take options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 dist
+bower_components
+node_modules
+tmp
+npm-debug.log

--- a/addon/services/fb.js
+++ b/addon/services/fb.js
@@ -4,13 +4,15 @@ export default Ember.Service.extend(Ember.Evented, {
   fbInitPromise: null,
   locale: null,
 
-  FBInit() {
+  FBInit(options = {}) {
     if (this.fbInitPromise) { return this.fbInitPromise; }
 
     const ENV = Ember.getOwner(this).resolveRegistration('config:environment');
 
+    var initSettings = Ember.$.extend({}, ENV.FB || {}, options);
+
     // Detect language configuration and store it.
-    const locale = ENV.FB.locale || 'en_US';
+    const locale = initSettings.locale || 'en_US';
     this.locale = locale;
 
     if (ENV.FB && ENV.FB.skipInit) {
@@ -19,7 +21,6 @@ export default Ember.Service.extend(Ember.Evented, {
     }
 
     var original = window.fbAsyncInit;
-    var initSettings = ENV.FB;
     if (!initSettings || !initSettings.appId || !initSettings.version) {
       return Ember.RSVP.reject('No settings for init');
     }

--- a/tests/unit/services/fb-test.js
+++ b/tests/unit/services/fb-test.js
@@ -34,14 +34,14 @@ test('FBInit define FB on window', function(assert) {
 });
 
 test('FBInit loads localized version', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   return this.subject().FBInit({
     appId: 'YOUR-APP-ID',
     version: 'v2.5',
     locale: 'es_ES'
-  }).then(function() {
-    assert.expect(this.subject().locale === 'es_ES');
+  }).then(() => {
+    assert.equal(this.subject().locale, 'es_ES', 'locale is localized');
     assert.ok(window.FB);
   });
 });


### PR DESCRIPTION
We've just updated this addon from 0.0.4 to 1.0.8 and noticed the ability to pass options to your init was missing.

Currently `FBInit` doesn't take any options so you cannot pass it a `locale` or `appId` to use. For instance, where we use this addon, we never know at build-time what `appId` to use. Instead, at run time, based on various criteria we determine which one to use.

* I've fixed the failing locale test
* Added a `.gitignore` to ignore the most common ember-cli build files