### PR TITLE
Return scopes from login

### DIFF
--- a/addon/services/fb.js
+++ b/addon/services/fb.js
@@ -146,7 +146,7 @@ export default Ember.Service.extend(Ember.Evented, {
           } else {
             Ember.run(null, reject, response);
           }
-        }, {scope: scope});
+        }, {scope: scope, return_scopes: true});
       });
     });
   },


### PR DESCRIPTION
"By setting the return_scopes option to true in the option object when calling FB.login(), you will receive a list of the granted permissions in the grantedScopes field on the authResponse object." -- https://developers.facebook.com/docs/reference/javascript/FB.login/v2.9