### PR TITLE
Added extra options hash to login function that get passed along with scope to fb.login

### DIFF
--- a/addon/services/fb.js
+++ b/addon/services/fb.js
@@ -136,8 +136,15 @@ export default Ember.Service.extend(Ember.Evented, {
     });
   },
 
-  login: function(scope) {
+  login: function(scope, options={}) {
+
     var service = this;
+    var params = {scope: scope, return_scopes: true};
+
+    if (options) {
+      params = Ember.assign(params, options);
+    }
+
     return this.FBInit().then(function() {
       return new Ember.RSVP.Promise(function(resolve, reject) {
         window.FB.login(function(response) {
@@ -147,7 +154,7 @@ export default Ember.Service.extend(Ember.Evented, {
           } else {
             Ember.run(null, reject, response);
           }
-        }, {scope: scope, return_scopes: true});
+        }, params);
       });
     });
   },


### PR DESCRIPTION
The main use case (for me) is to be able to pass the `default_audience` param to the login method so that an app can request to be able to post publicly rather than just to 'Friends' which is the default.

<img width="599" alt="screen shot 2017-07-25 at 3 11 40 pm" src="https://user-images.githubusercontent.com/558730/28554125-d14d0194-714b-11e7-9f0e-55c8ad583a9e.png">

I'm happy to add tests but would appreciate some direction as not sure of the best way of testing this functionality.