### PR TITLE
FIX: Token should be refreshed if error code is 2500

### DIFF
--- a/addon/services/fb.js
+++ b/addon/services/fb.js
@@ -103,7 +103,7 @@ export default Service.extend(Evented, {
 
   api() {
     return this._api(...arguments).catch((error) => {
-      if (this.refreshToken && error.code === 190) {
+      if (this.refreshToken && (error.code === 190 || error.code === 2500)) {
         console.debug('Trying to refresh Facebook session an re-do the Facebook API request');
         return this.getLoginStatus().then((response) => {
           if (response.status === 'connected') {


### PR DESCRIPTION
Sometimes Facebook api returns this
"{"message":"An active access token must be used to query information about the current user.","type":"OAuthException","code":2500,"fbtrace_id":"EzKntVw1fF8"}"

which seems similiar to the error code 190