### PR TITLE
Replace jQuery dependency with vanilla JS solution for getScript

### DIFF
--- a/addon/services/fb.js
+++ b/addon/services/fb.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import Evented from '@ember/object/evented';
 import Service from '@ember/service';
 import { getOwner } from '@ember/application';
@@ -39,9 +37,11 @@ export default Service.extend(Evented, {
         run.next(null, resolve);
       };
       // URL for the SDK is built according to locale. Defaults to `en_US`.
-      $.getScript(`https://connect.facebook.net/${locale}/sdk.js`, function() {
-        // Do nothing here, wait for window.fbAsyncInit to be called.
-      });
+      const scriptURL = `https://connect.facebook.net/${locale}/sdk.js`;
+      const head = document.getElementsByTagName('head')[0];
+      const script = document.createElement('script');
+      script.src = scriptURL;
+      head.appendChild(script);
     }).then(function() {
       if (original) {
         window.fbAsyncInit = original;


### PR DESCRIPTION
Hello. I am in a process of updating an Ember app and removing jQuery, and fb.ui() in your service caused an error. Since you only rely on jQuery for getScript(), I've forked and replaced it with plain JS solution. Maybe you'll want to include this in your project.